### PR TITLE
Fix CAH trap weight initalization and image net example scale factor

### DIFF
--- a/breaching/cases/malicious_modifications/imprint.py
+++ b/breaching/cases/malicious_modifications/imprint.py
@@ -223,7 +223,7 @@ class CuriousAbandonHonesty(ImprintBlock):
         negative_weight_indices = indices[:, : int(N / 2)]
         positive_weight_indices = indices[:, int(N / 2) :]
 
-        sampled_weights = torch.randn(K, int(N / 2)) * sigma
+        sampled_weights = torch.abs(torch.randn(K, int(N / 2)) * sigma) * -1
 
         negative_samples = sampled_weights
         positive_samples = -scale_factor * sampled_weights


### PR DESCRIPTION
The current implementation of the trap weight initialization is flawed, as it samples the negative weights using `torch.randn`, resulting in mixed positive and negative values. I fixed this by wrapping it with `torch.abs` and multiplying by -1 to ensure full negative weights, similar to how it is done in [this implementation](https://colab.research.google.com/drive/17uB-plUyxNo19HVJBOKGDVWo88IiR74o?usp=sharing#scrollTo=NQ0l1_XGGJHc).

Additionally, I changed the sign of the scale factor in the ImageNet example notebook, as it was negative, which lead to a double negative in the line `positive_samples = -scale_factor * sampled_weights`.

The fact that the example notebook still reproduced images despite these flaws, can simply be attributed to the fact that even without adversarial weight initialization there is a chance for single-image neuron activations (see passive attack of the CAH paper).

With these adjustments, the example notebook reproduces ~50% of the training images, as opposed to ~30% previously.


 