### PR TITLE
fix: convert tensor to cpu when its cuda

### DIFF
--- a/breaching/utils.py
+++ b/breaching/utils.py
@@ -282,6 +282,8 @@ def dump_metrics(cfg, metrics):
     sanitized_metrics = dict()
     for metric, val in metrics.items():
         try:
+            if torch.is_tensor(val) and val.is_cuda:
+                val = val.cpu()
             sanitized_metrics[metric] = np.asarray(val).item()
         except ValueError:
             sanitized_metrics[metric] = np.asarray(val).tolist()


### PR DESCRIPTION
When using gpu instead of cpu at 

```
modified   breaching/config/case/impl/default.yaml
@@ -7,7 +7,7 @@ sample_with_replacement: False
 dtype: float # this has to be float when mixed_precision is True
 non_blocking: True
 sharing_strategy: file_descriptor
-enable_gpu_acc: False # use this flag to disable GPU usage
+enable_gpu_acc: True # use this flag to disable GPU usage
```

dump_metrics will fail:

```
/home/base/.local/lib/python3.11/site-packages/hydra/_internal/hydra.py:119: UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.
See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information.
  ret = run_job(
[2025-08-14 20:04:15,577] --------------------------------------------------------------
[2025-08-14 20:04:15,578] -----Launching federating learning breach experiment! --------
[2025-08-14 20:04:15,583] case:
  data:
    db:
      name: null
    name: CIFAR10
    modality: vision
    task: classification
    path: ~/data
    size: 50000
    classes: 10
    shape:
    - 3
    - 32
    - 32
    normalize: true
    mean:
    - 0.4914672374725342
    - 0.4822617471218109
    - 0.4467701315879822
    std:
    - 0.24703224003314972
    - 0.24348513782024384
    - 0.26158785820007324
    augmentations_train:
      RandomCrop:
      - 32
      - 4
      RandomHorizontalFlip: 0.5
    augmentations_val: null
    default_clients: 10
    partition: balanced
    examples_from_split: validation
    batch_size: 128
    caching: false
  impl:
    shuffle: false
    sample_with_replacement: false
    dtype: float
    non_blocking: true
    sharing_strategy: file_descriptor
    enable_gpu_acc: true
    benchmark: true
    deterministic: false
    pin_memory: true
    threads: 0
    persistent_workers: false
    mixed_precision: false
    grad_scaling: true
    JIT: null
    validate_every_nth_step: 10
    checkpoint:
      name: null
      save_every_nth_step: 10
    enable_huggingface_offline_mode: true
  server:
    name: honest_but_curious
    pretrained: true
    model_state: default
    provide_public_buffers: true
    has_external_data: false
    num_queries: 1
  user:
    user_type: local_gradient
    user_idx: 0
    num_data_points: 1
    provide_buffers: false
    provide_labels: true
    provide_num_data_points: true
    local_diff_privacy:
      gradient_noise: 0.0
      input_noise: 0.0
      distribution: laplacian
      per_example_clipping: 0.0
  name: single_image_small
  model: ConvNet
  num_queries: 1
attack:
  type: invertinggradients
  attack_type: optimization
  label_strategy: bias-corrected
  text_strategy: run-embedding
  token_recovery: from-labels
  objective:
    type: cosine-similarity
    scale: 1.0
    task_regularization: 0.0
  restarts:
    num_trials: 1
    scoring: cosine-similarity
  init: randn
  normalize_gradients: false
  optim:
    optimizer: adam
    signed: hard
    step_size: 0.1
    boxed: true
    max_iterations: 24000
    step_size_decay: step-lr
    langevin_noise: 0.0
    warmup: 0
    grad_clip: null
    callback: 1000
  augmentations: null
  differentiable_augmentations: false
  regularization:
    total_variation:
      scale: 0.2
      inner_exp: 1
      outer_exp: 1
  impl:
    dtype: float
    mixed_precision: false
    JIT: null
base_dir: outputs
seed: 905559562
name: default
dryrun: true
enable_gpu_acc: true
num_trials: 100
save_reconstruction: false

[2025-08-14 20:04:15,613] Platform: linux, Python: 3.11.11, PyTorch: 2.7.0+cu126
[2025-08-14 20:04:15,625] CPUs: 24, GPUs: 1 on a8428898f2e2.
[2025-08-14 20:04:15,627] GPU : NVIDIA GeForce RTX 3090
Model architecture ConvNet loaded with 2,904,970 parameters and 3,208 buffers.
Overall this is a data ratio of     946:1 for target shape [1, 3, 32, 32] given that num_queries=1.
User (of type UserSingleStep) with settings:
    Number of data points: 1

    Threat model:
    User provides labels: True
    User provides buffers: False
    User provides number of data points: True

    Data:
    Dataset: CIFAR10
    user: 0
    
        
Server (of type HonestServer) with settings:
    Threat model: Honest-but-curious
    Number of planned queries: 1
    Has external/public data: False

    Model:
        model specification: ConvNet
        model state: default
        public buffers: True

    Secrets: {}
    
Attacker (of type OptimizationBasedAttacker) with settings:
    Hyperparameter Template: invertinggradients

    Objective: Cosine Similarity with scale=1.0 and task reg=0.0
    Regularizers: Total Variation, scale=0.2. p=1 q=1. 
    Augmentations: 

    Optimization Setup:
        optimizer: adam
        signed: hard
        step_size: 0.1
        boxed: True
        max_iterations: 24000
        step_size_decay: step-lr
        langevin_noise: 0.0
        warmup: 0
        grad_clip: None
        callback: 1000
        
[2025-08-14 20:04:16,446] Computing user update on user 0 in model mode: eval.
[2025-08-14 20:04:17,323] | It: 1 | Rec. loss: 0.4484 |  Task loss: 2.2961 | T: 0.36s
[2025-08-14 20:04:17,358] Optimal candidate solution with rec. loss 0.0075 selected.
[2025-08-14 20:04:17,360] Starting evaluations for attack effectiveness report...
/usr/local/lib/python3.11/dist-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
  warnings.warn(
/usr/local/lib/python3.11/dist-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=AlexNet_Weights.IMAGENET1K_V1`. You can also use `weights=AlexNet_Weights.DEFAULT` to get the most up-to-date weights.
  warnings.warn(msg)
/media/data/base/breaching/breaching/analysis/metrics.py:24: UserWarning: To utilize wavelet SSIM, install pytorch wavelets from https://github.com/fbcotter/pytorch_wavelets.
  warnings.warn(
[2025-08-14 20:04:19,994] METRICS: | MSE: 0.1156 | PSNR: 9.37 | FMSE: 1.6724e-08 | LPIPS: 0.44|
 R-PSNR: 10.52 | IIP-pixel: 0.00% | SSIM: nan | max R-PSNR: 10.52 | max SSIM: nan | Label Acc: 100.00%
Error executing job with overrides: ['dryrun=True']
Traceback (most recent call last):
  File "/media/data/base/breaching/simulate_breach.py", line 74, in main_launcher
    main_process(0, 1, cfg)
  File "/media/data/base/breaching/simulate_breach.py", line 56, in main_process
    breaching.utils.dump_metrics(cfg, metrics)
  File "/media/data/base/breaching/breaching/utils.py", line 287, in dump_metrics
    sanitized_metrics[metric] = np.asarray(val).item()
                                ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/torch/_tensor.py", line 1225, in __array__
    return self.numpy()
           ^^^^^^^^^^^^
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.

```

This commit checks when val is a tensor and if it is, checks if it is an cuda device, coverting it to cpu before sanitizing the metric. 

After the change the code runs with sucess:

```
/home/base/.local/lib/python3.11/site-packages/hydra/_internal/hydra.py:119: UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.
See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information.
  ret = run_job(
[2025-08-14 20:07:22,257] --------------------------------------------------------------
[2025-08-14 20:07:22,259] -----Launching federating learning breach experiment! --------
[2025-08-14 20:07:22,272] case:
  data:
    db:
      name: null
    name: CIFAR10
    modality: vision
    task: classification
    path: ~/data
    size: 50000
    classes: 10
    shape:
    - 3
    - 32
    - 32
    normalize: true
    mean:
    - 0.4914672374725342
    - 0.4822617471218109
    - 0.4467701315879822
    std:
    - 0.24703224003314972
    - 0.24348513782024384
    - 0.26158785820007324
    augmentations_train:
      RandomCrop:
      - 32
      - 4
      RandomHorizontalFlip: 0.5
    augmentations_val: null
    default_clients: 10
    partition: balanced
    examples_from_split: validation
    batch_size: 128
    caching: false
  impl:
    shuffle: false
    sample_with_replacement: false
    dtype: float
    non_blocking: true
    sharing_strategy: file_descriptor
    enable_gpu_acc: true
    benchmark: true
    deterministic: false
    pin_memory: true
    threads: 0
    persistent_workers: false
    mixed_precision: false
    grad_scaling: true
    JIT: null
    validate_every_nth_step: 10
    checkpoint:
      name: null
      save_every_nth_step: 10
    enable_huggingface_offline_mode: true
  server:
    name: honest_but_curious
    pretrained: true
    model_state: default
    provide_public_buffers: true
    has_external_data: false
    num_queries: 1
  user:
    user_type: local_gradient
    user_idx: 0
    num_data_points: 1
    provide_buffers: false
    provide_labels: true
    provide_num_data_points: true
    local_diff_privacy:
      gradient_noise: 0.0
      input_noise: 0.0
      distribution: laplacian
      per_example_clipping: 0.0
  name: single_image_small
  model: ConvNet
  num_queries: 1
attack:
  type: invertinggradients
  attack_type: optimization
  label_strategy: bias-corrected
  text_strategy: run-embedding
  token_recovery: from-labels
  objective:
    type: cosine-similarity
    scale: 1.0
    task_regularization: 0.0
  restarts:
    num_trials: 1
    scoring: cosine-similarity
  init: randn
  normalize_gradients: false
  optim:
    optimizer: adam
    signed: hard
    step_size: 0.1
    boxed: true
    max_iterations: 24000
    step_size_decay: step-lr
    langevin_noise: 0.0
    warmup: 0
    grad_clip: null
    callback: 1000
  augmentations: null
  differentiable_augmentations: false
  regularization:
    total_variation:
      scale: 0.2
      inner_exp: 1
      outer_exp: 1
  impl:
    dtype: float
    mixed_precision: false
    JIT: null
base_dir: outputs
seed: 1499022481
name: default
dryrun: true
enable_gpu_acc: true
num_trials: 100
save_reconstruction: false

[2025-08-14 20:07:22,305] Platform: linux, Python: 3.11.11, PyTorch: 2.7.0+cu126
[2025-08-14 20:07:22,337] CPUs: 24, GPUs: 1 on a8428898f2e2.
[2025-08-14 20:07:22,340] GPU : NVIDIA GeForce RTX 3090
Model architecture ConvNet loaded with 2,904,970 parameters and 3,208 buffers.
Overall this is a data ratio of     946:1 for target shape [1, 3, 32, 32] given that num_queries=1.
User (of type UserSingleStep) with settings:
    Number of data points: 1

    Threat model:
    User provides labels: True
    User provides buffers: False
    User provides number of data points: True

    Data:
    Dataset: CIFAR10
    user: 0
    
        
Server (of type HonestServer) with settings:
    Threat model: Honest-but-curious
    Number of planned queries: 1
    Has external/public data: False

    Model:
        model specification: ConvNet
        model state: default
        public buffers: True

    Secrets: {}
    
Attacker (of type OptimizationBasedAttacker) with settings:
    Hyperparameter Template: invertinggradients

    Objective: Cosine Similarity with scale=1.0 and task reg=0.0
    Regularizers: Total Variation, scale=0.2. p=1 q=1. 
    Augmentations: 

    Optimization Setup:
        optimizer: adam
        signed: hard
        step_size: 0.1
        boxed: True
        max_iterations: 24000
        step_size_decay: step-lr
        langevin_noise: 0.0
        warmup: 0
        grad_clip: None
        callback: 1000
        
[2025-08-14 20:07:23,425] Computing user update on user 0 in model mode: eval.
[2025-08-14 20:07:24,404] | It: 1 | Rec. loss: 0.4466 |  Task loss: 2.2830 | T: 0.38s
[2025-08-14 20:07:24,457] Optimal candidate solution with rec. loss 0.0060 selected.
[2025-08-14 20:07:24,459] Starting evaluations for attack effectiveness report...
/usr/local/lib/python3.11/dist-packages/torchvision/models/_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
  warnings.warn(
/usr/local/lib/python3.11/dist-packages/torchvision/models/_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=AlexNet_Weights.IMAGENET1K_V1`. You can also use `weights=AlexNet_Weights.DEFAULT` to get the most up-to-date weights.
  warnings.warn(msg)
/media/data/base/breaching/breaching/analysis/metrics.py:24: UserWarning: To utilize wavelet SSIM, install pytorch wavelets from https://github.com/fbcotter/pytorch_wavelets.
  warnings.warn(
[2025-08-14 20:07:27,342] METRICS: | MSE: 0.1151 | PSNR: 9.39 | FMSE: 4.0266e-08 | LPIPS: 0.40|
 R-PSNR: 10.60 | IIP-pixel: 0.00% | SSIM: nan | max R-PSNR: 10.60 | max SSIM: nan | Label Acc: 100.00%
[2025-08-14 20:07:27,352] -------------------------------------------------------------
[2025-08-14 20:07:27,353] Finished computations default with total train time: 0:00:05.093193
[2025-08-14 20:07:27,355] -----------------Job finished.-------------------------------

```

Also

The same situation may occur at breaching/attacks/analytic_attack.py:

```
        for idx, embedding in enumerate(estimated_final_embeddings):
            if "abs" in self.cfg.matcher:
                costs[idx] = np.abs(self.vcorrcoef(breached_embeddings.numpy(), embedding.numpy())).max().item()
            else:
                costs[idx] = self.vcorrcoef(breached_embeddings.numpy(), embedding.numpy()).max().item()
        return costs.view_as(final_tokens)

```

I had resolved it by adding:

```
        for idx, embedding in enumerate(estimated_final_embeddings):
            if torch.is_tensor(embedding):
                embedding = embedding.cpu()
            if "abs" in self.cfg.matcher:
                costs[idx] = np.abs(self.vcorrcoef(breached_embeddings.numpy(), embedding.numpy())).max().item()
            else:
                costs[idx] = self.vcorrcoef(breached_embeddings.numpy(), embedding.numpy()).max().item()
        return costs.view_as(final_tokens)

```

But if forgot which case triggered it, so I dont have any artifact right now to prove that, but if you are okay I can add this to this PR as well. 


