### PR TITLE
chore: document breaching parameters for case/impl config

### DIFF
--- a/breaching/config/case/impl/README.md
+++ b/breaching/config/case/impl/README.md
@@ -1,45 +1,45 @@
 ### Dataloader implementation choices:
-#### Turn these off for better reproducibility of experiments
-- shuffle: @boolean DEFAULT=FALSE
-  - Samples elements randomly. If without replacement, then sample from a shuffled dataset.
-- sample_with_replacement: @boolean DEFAULT=False
-  - Used along with shuffle. Samples are drawn on-demand with replacement if True
 
-### PyTorch configuration
-- dtype: @torch.dtype DEFAULT=float
-  - This has to be float when mixed_precision is True. A torch.dtype is an object that represents the data type of torch.Tensor. PyTorch has several different data types, refer to https://docs.pytorch.org/docs/stable/tensor_attributes.html for more info.
+| Variable                | Type    | Default Value | Description                                                                             |
+|-------------------------|---------|---------------|-----------------------------------------------------------------------------------------|
+| shuffle                 | boolean | False         | Samples elements randomly. If without replacement, then sample from a shuffled dataset. |
+|                         |         |               |                                                                                         |
+| sample_with_replacement | boolean | False         | Used along with shuffle. Samples are drawn on-demand with replacement if True           |
 
-- non_blocking: @boolean DEFAULT=True
-  - Not used.
+*Turn these off for better reproducibility of experiments*
 
-- sharing_strategy: @string DEFAULT=file_descriptor
-  - Defines the strategy of torch.multiprocessing to provide shared views on the same data in diferent processes. Refer to https://docs.pytorch.org/docs/stable/multiprocessing.html#sharing-strategies for more info.
+### PyTorch configuration:
 
-- enable_gpu_acc: @boolean DEFAULT=FALSE
-  - Uses CUDA as torch device instead of CPU. 
-
-- benchmark: @boolean DEFAULT=True
-  - Causes cuDNN to benchmark multiple convolution algorithms and select the fastest.
-- deterministic: @boolean DEFAULT=False 
-  - This option will disable cuDNN non-deterministic ops.
-
-- pin_memory: @boolean DEFAULT=True
-- threads: @int DEFAULT=0
-  - Maximal number of cpu dataloader workers used per GPU
-- persistent_workers: @boolean DEFAULT=False
-
-- mixed_precision: @boolean DEFAULT=False
-- grad_scaling: @boolean DEFAULT=True 
-  - This is a no-op if mixed-precision is off
-- JIT: "script"|"trace"|null DEFAULT=null 
-  - script currently break autocast mixed precision
-  - trace breaks training
-
-- validate_every_nth_step: @int DEFAULT=10
-
-- checkpoint: @object 
-	checkpont.name: @string
-  - checkpoint.save_every_nth_step: @int DEFAULT=10
-
-- enable_huggingface_offline_mode: @boolean DEFAULT=True 
-  - huggingface` needs an internet connection for metrics, datasets and tokenizers. After caching these objects, it can be turned to offline mode with this argument.
+| Variable                        | Type        | Default Value   | Description                                                                                                                                                                                                                                                |
+|---------------------------------|-------------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| dtype                           | torch.dtype | float           | This has to be float when mixed_precision is True. A torch.dtype is an object that represents the data type of torch.Tensor. PyTorch has several different data types, refer to https://docs.pytorch.org/docs/stable/tensor_attributes.html for more info. |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| non_blocking                    | boolean     | True            | Not used.                                                                                                                                                                                                                                                  |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| sharing_strategy                | string      | file_descriptor | Defines the strategy of torch.multiprocessing to provide shared views on the same data in diferent processes. Refer to https://docs.pytorch.org/docs/stable/multiprocessing.html#sharing-strategies for more info.                                         |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| enable_gpu_acc                  | boolean     | False           | Uses CUDA as torch device instead of CPU                                                                                                                                                                                                                   |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| benchmark                       | booloan     | True            | This option will disable cuDNN non-deterministic ops.                                                                                                                                                                                                      |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| pin_memory                      | boolean     | True            |                                                                                                                                                                                                                                                            |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| threads                         | int         | 0               | Maximal number of cpu dataloader workers used per GPU                                                                                                                                                                                                      |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| persistent_workes               | boolean     | False           |                                                                                                                                                                                                                                                            |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| mixed_precision                 | boolean     | True            |                                                                                                                                                                                                                                                            |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| grad_scaling                    | boolean     | True            | This is a no-op if mixed-precision is off                                                                                                                                                                                                                  |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| JIT                             | Enum        | null            | Can be "script", "trace" or null                                                                                                                                                                                                                           |
+|                                 |             |                 | script: currently break outcast mixed precision                                                                                                                                                                                                            |
+|                                 |             |                 | trace: breaks training                                                                                                                                                                                                                                     |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| validate_every_nth_step         | int         | 10              |                                                                                                                                                                                                                                                            |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| checkpoint                      | object      |                 |                                                                                                                                                                                                                                                            |
+| checkpoint.name                 | string      |                 |                                                                                                                                                                                                                                                            |
+| checkpoint.save_every_nth_step  | int         | 10              |                                                                                                                                                                                                                                                            |
+|                                 |             |                 |                                                                                                                                                                                                                                                            |
+| enable_huggingface_offline_mode | boolean     | True            | huggingface needs an internet connection for metrics, datasets and tokenizers. After caching these objects, it can be turned to offline mode with this argument.                                                                                          |


### PR DESCRIPTION
Hello. This is a continuation of #19 but it does not closes it. 

I've decide to first add a consistent markdown definition of the parameters before messing with hydra cmd options. This keeps the additions in the "architecture" that the repo implements, providing individual README files at each module and given the pertinent information of the current module. 

So this PR disposes the parameters of case/impl as markdown tables, that can be readable online and still has a decent visualization offline when accessing the file directly.

You can check how the tables are rendered at: 
https://github.com/RageAgainstTheMachineLearning/breaching/tree/docs/impl/breaching/config/case/impl

If you have any suggestions, or prefer a formatting without tables, let me know!