### PR TITLE
chore: document breaching parameters for case/data config

### DIFF
--- a/breaching/config/case/data/README.md
+++ b/breaching/config/case/data/README.md
@@ -1,51 +1,54 @@
 ### Commom parameters
 
-| Variable | Type           | Description                                                                                               |
-|----------|----------------|-----------------------------------------------------------------------------------------------------------|
-| Name     | string         | Defaults generality to the config file name, and the name of the dataset itself                           |
-|          |                |                                                                                                           |
-| modality | enum           | "vision" or "text", based in the dataset nature                                                           |
-|          |                |                                                                                                           |
-| task     | enum           | Vision datasets: defaults to "classification".                                                            |
-|          |                | Text datasets: can be "masked-lm" or  "causal-lm"                                                         |
-|          |                |                                                                                                           |
-|          |                |                                                                                                           |
-| path     | string         | The path of the dataset in the system. Defaults to "~/data".                                              |
-|          |                |                                                                                                           |
-| size     | int            | The size of the data in the dataset                                                                       |
-|          |                |                                                                                                           |
-| shape    | 3-tuple or int | Vision datasets: it is a 3-tuple of (Channel, width, height) of the images on the dataset                 |
-|          |                | Text datasets: it is the sequence_lenght of the dataset, that represents the number of tokens/words in it |
+| Variable | Type    | Description                                                                                               |
+|----------|---------|-----------------------------------------------------------------------------------------------------------|
+| name     | string  | Defaults to the name of the dataset itself.                                                               |
+|          |         |                                                                                                           |
+| modality | enum    | "vision" or "text", based in the dataset nature.                                                          |
+|          |         |                                                                                                           |
+| task     | enum    | Vision datasets: defaults to "classification".                                                            |
+|          |         | Text datasets: can be "masked-lm" or  "causal-lm".                                                        |
+|          |         |                                                                                                           |
+| path     | string  | The path of the dataset in the system. Defaults to "~/data".                                              |
+|          |         |                                                                                                           |
+| size     | int     | The size of the data in the dataset                                                                       |
+|          |         |                                                                                                           |
+| shape    | 3-tuple | Vision datasets: it is a 3-tuple of (channel, width, heigth) of the images on the dataset                 |
+|          | int     | Text datasets: it is the sequence_lenght of the dataset, that represents the number of tokens/words in it |
 
 #### Federated Learning specifics:
 
-| Variable            | Type | Description                                   |
-|---------------------|------|-----------------------------------------------|
-| default_clients     | int  | Estimate on number of articles in dataset     |
-|                     |      |                                               |
-| partition           | enum | Can be "given", "balanced" or "unique-class". |
-|                     |      | given: use natural data partition             |
-|                     |      | balanced:                                     |
-|                     |      | unique-class:                                 |
-|                     |      |                                               |
-| examples_from_split | enum | Can be "train", "training" or "validation".   |
-|                     |      | train:                                        |
-|                     |      | training:                                     |
-|                     |      | validation:                                   |
-
-
+| Variable            | Type | Description                                                       |
+|---------------------|------|-------------------------------------------------------------------|
+| default_clients     | int  | Estimate on number of articles in dataset                         |
+|                     |      |                                                                   |
+| partition           | enum | Used by server module when preparing the dataset for use.         |
+|                     |      | given: use natural data partition. Default text dataset partition |
+|                     |      | balanced:                                                         |
+|                     |      | unique-class:                                                     |
+|                     |      | mixup:                                                            |
+|                     |      | feat_est:                                                         |
+|                     |      | random-full:                                                      |
+|                     |      | random:                                                           |
+|                     |      | none:                                                             |
+|                     |      |                                                                   |
+| examples_from_split | enum | Used by server module when preparing the dataset for use.         |
+|                     |      | train:                                                            |
+|                     |      | training:                                                         |
+|                     |      | validation:                                                       |
 
 #### Data-specific implementation constants:
 
 | Variable   | Type    | Description                                                                                           |
 |------------|---------|-------------------------------------------------------------------------------------------------------|
-| batch_size | int     |                                                                                                       |
+| batch_size | int     | number of samples processed together in one pass                                                      |
 |            |         |                                                                                                       |
 | caching    | boolean |                                                                                                       |
 |            |         |                                                                                                       |
-| db         | enum    | Can be "none" or "LMDB"                                                                               |
+| db         | enum    | Can be "none" or "LMDB".                                                                              |
 |            |         | Database Setup. Use the cmd-line hydra overload feature to activate the LMDB module with data.db=LMDB |
 
+<hr />
 
 ### Vision datasets specific parameters:
 
@@ -55,40 +58,44 @@
 
 #### Preprocessing:
 
-| Variable  | Type    | Description |
-|-----------|---------|-------------|
-| normalize | boolean |             |
-|           |         |             |
-| mean      | 3-tuple |             |
-|           |         |             |
-| std       | 3-tuple |             |
+| Variable  | Type    | Description                                           |
+|-----------|---------|-------------------------------------------------------|
+| normalize | boolean | Scales pixel values to an standard range              |
+|           |         |                                                       |
+| mean      | 3-tuple | Average pixel values across the entire dataset        |
+|           |         |                                                       |
+| std       | 3-tuple | Standard deviation of pixel values across the dataset |
 
 #### Data Augmentations:
 
-| Variable                                 | Type   | Description |
-|------------------------------------------|--------|-------------|
-| augmentations_train                      | object |             |
-| augmentations_train.RandomCrop           | tuple  |             |
-| augmentations_train.RandomHorizontalFlip | float  |             |
-|                                          |        |             |
-| augmentations_val                        | object |             |
-| augmentations_val.Resize                 | int    |             |
-| augmentations_val.CenterCrop             | int    |             |
+| Variable                                 | Type   | Description                                                       |
+|------------------------------------------|--------|-------------------------------------------------------------------|
+| augmentations_train                      | object |                                                                   |
+| augmentations_train.RandomCrop           | tuple  | Randomly crops an image to the specified size to create variation |
+| augmentations_train.RandomHorizontalFlip | float  | Ramdomly flips image left-right                                   |
+|                                          |        |                                                                   |
+| augmentations_val                        | object |                                                                   |
+| augmentations_val.Resize                 | int    | Resizes image to fixed dimensions                                 |
+| augmentations_val.CenterCrop             | int    | Crops center portion to exact size for consistent evaluation      |
+
+<hr />
 
 ### Text datasets specific parameters:
 
 #### Only used when task=masked-lm:
 
-| Variable       | Type    | Description |
-|----------------|---------|-------------|
-| mlm_pobability | float   |             |
-|                |         |             |
-| disable_mlm    | boolean |             |
+| Variable        | Type    | Description                                                                                                      |
+|-----------------|---------|------------------------------------------------------------------------------------------------------------------|
+| mlm_probability | float   | Defaults to "0.15". It is the probability that any given token will be masked in Masked Language Modeling (MLM). |
+|                 |         |                                                                                                                  |
+| disable_mlm     | boolean | Defaults to "False". Disables the MLM.                                                                           |
 
 #### Preprocessing:
 
-| Variable   | Type | Description |
-|------------|------|-------------|
-| tokenizer  | enum |             |
-|            |      |             |
-| vocab_size | int  |             |
+| Variable   | Type | Description                                   |
+|------------|------|-----------------------------------------------|
+| tokenizer  | enum | Model used for split text into smaller units. |
+|            |      | Can be "GPT-2" and "bert-base-uncased"        |
+|            |      |                                               |
+| vocab_size | int  | Number of unique tokens in model dictionary.  |
+


### PR DESCRIPTION
You can view the readme at: https://github.com/RageAgainstTheMachineLearning/breaching/tree/docs/data/breaching/config/case/data

I tried to create three sections, one for common parameters, and two others for each text/visual specific parameters.

Let me know if it you would prefer another way to define those parameters.