### PR TITLE
fix: rgap attack execution on cuda device

### DIFF
--- a/breaching/attacks/recursive_attack.py
+++ b/breaching/attacks/recursive_attack.py
@@ -17,6 +17,10 @@ from .auxiliaries.recursive_attack import (
     inverse_leakyrelu,
 )
 
+import logging
+
+log = logging.getLogger(__name__)
+
 
 class RecursiveAttacker(_BaseAttacker):
     """Implements a thin wrapper around the original R-GAP code.
@@ -69,7 +73,7 @@ class RecursiveAttacker(_BaseAttacker):
 
         # Initialize at last layer:
         module = all_modules[0]
-        print(module)
+        log.info(f"{module}")
 
         w = module.weight.detach().cpu().numpy()
         if module.bias is None:
@@ -81,7 +85,7 @@ class RecursiveAttacker(_BaseAttacker):
             # For simplicity assume y as known here. For details please refer to the paper.
             y = 0.1  # this is a simplification the orignal paper's code only works for binary class.
 
-            print(f"pred_: {u/y:.1e}, udldu: {udldu:.1e}, udldu_:{-u/(1+np.exp(u)):.1e}")
+            log.info(f"pred_: {u/y:.1e}, udldu: {udldu:.1e}, udldu_:{-u/(1+np.exp(u)):.1e}")
             k = -y / (1 + np.exp(u))
             k = k.reshape(1, -1).astype(np.float32)
             x_, last_weight = fcn_reconstruction(k=k, gradient=g), w
@@ -99,7 +103,7 @@ class RecursiveAttacker(_BaseAttacker):
         # Recurse through all other layers. Expects an alternating structure  of activation and linear layer
         # For R-GAP the activation has to be invertible
         for idx, module in enumerate(all_modules[1:]):
-            print(module)
+            log.info(f"{module}")
 
             if isinstance(module, (torch.nn.LeakyReLU, torch.nn.Identity)):  # or any activation function really!
                 # derive activation function
@@ -130,7 +134,7 @@ class RecursiveAttacker(_BaseAttacker):
                 k = np.multiply(np.matmul(last_weight.transpose(), k)[x_mask], da.transpose())
 
             if isinstance(module, (torch.nn.Conv2d, torch.nn.Linear)):
-                g = original_dy_dx[grad_idx].cpu().numpy() # this only works for the given nets with bias=None
+                g = original_dy_dx[grad_idx].cpu().numpy()  # this only works for the given nets with bias=None
                 grad_idx -= 1
                 w = module.weight.detach().cpu().numpy()
                 if isinstance(module, torch.nn.Conv2d):

--- a/breaching/attacks/recursive_attack.py
+++ b/breaching/attacks/recursive_attack.py
@@ -130,7 +130,7 @@ class RecursiveAttacker(_BaseAttacker):
                 k = np.multiply(np.matmul(last_weight.transpose(), k)[x_mask], da.transpose())
 
             if isinstance(module, (torch.nn.Conv2d, torch.nn.Linear)):
-                g = original_dy_dx[grad_idx].numpy()  # this only works for the given nets with bias=None
+                g = original_dy_dx[grad_idx].cpu().numpy() # this only works for the given nets with bias=None
                 grad_idx -= 1
                 w = module.weight.detach().cpu().numpy()
                 if isinstance(module, torch.nn.Conv2d):


### PR DESCRIPTION
Hello. I hope you're doing fine. 

When executing the rgap attack with GPU acceleration the following error will occur:

```
$ python simulate_breach.py case=1_single_image_small case.model=cnn6 attack=rgap case.impl.enable_gpu_acc=True

...

Error executing job with overrides: ['case=1_single_image_small', 'case.model=cnn6', 'attack=rgap', 'case.impl.enable_gpu_acc=True']
Traceback (most recent call last):
  File "/breaching/simulate_breach.py", line 74, in main_launcher
    main_process(0, 1, cfg)
  File "/breaching/simulate_breach.py", line 46, in main_process
    reconstructed_user_data, stats = attacker.reconstruct(payloads, shared_user_data, server.secrets, dryrun=cfg.dryrun)
  File "/breaching/breaching/attacks/recursive_attack.py", line 49, in reconstruct
    inputs = self._rgap(list(user_data["gradients"]), labels, model, feature_shapes)
  File "/breaching/breaching/attacks/recursive_attack.py", line 133, in _rgap
    g = original_dy_dx[grad_idx].numpy()  # this only works for the given nets with bias=None
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

Moving `original_dy_dx[grad_idx]` to `cpu()` before prevents this from happening.

I also took the liberty of moving `print()` statements to `log.info()` because print will only flush to stdout at the end of the execution, while log.info will flush it as it happens. This helps because rgap really takes it times, and a little feedback can shows that everything is running well. 

Let me know what you think and if you desire any other thing. 

Thanks!