### PR TITLE
fix: return item() on closure to avoid LBFGS warning

### DIFF
--- a/breaching/attacks/optimization_with_label_attack.py
+++ b/breaching/attacks/optimization_with_label_attack.py
@@ -6,7 +6,6 @@ And it does also work in simpler settings as in the original paper.
 In some cases turning this on can stabilize an L-BFGS optimizer.
 """
 
-import math
 import torch
 import time
 
@@ -134,17 +133,17 @@ class OptimizationJointAttacker(OptimizationBasedAttacker):
                         dim=-1
                     ).mean() / torch.log(torch.as_tensor(p.shape[-1], dtype=torch.float))
                     log.info(
-                        f"| It: {iteration + 1} | Rec. loss: {objective_value:2.4f} | "
+                        f"| It: {iteration + 1} | Rec. loss: {objective_value.item():2.4f} | "
                         f" Task loss: {task_loss.item():2.4f} | T: {timestamp - current_wallclock:4.2f}s | "
                         f" Label Entropy: {label_entropy:2.4f}."
                     )
                     current_wallclock = timestamp
 
-                if not math.isfinite(objective_value):
+                if not torch.isfinite(objective_value):
                     log.info(f"Recovery loss is non-finite in iteration {iteration}. Cancelling reconstruction!")
                     break
 
-                stats[f"Trial_{trial}_Val"].append(objective_value)
+                stats[f"Trial_{trial}_Val"].append(objective_value.item())
 
                 if dryrun:
                     break
@@ -201,7 +200,7 @@ class OptimizationJointAttacker(OptimizationBasedAttacker):
                         pass
 
             self.current_task_loss = total_task_loss  # Side-effect this because of L-BFGS closure limitations :<
-            return total_objective.item()
+            return total_objective.detach()
 
         return closure
 


### PR DESCRIPTION
While running attacks that use LBFGS to calculate the loss, torch keeps flushing a warning to the user:

```
/breaching/.venv/lib/python3.10/site-packages/torch/optim/lbfgs.py:457: UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
Consider using tensor.detach() first. (Triggered internally at /pytorch/torch/csrc/autograd/generated/python_variable_methods.cpp:835.)
  loss = float(closure())
```

This is related to issue [#160197](https://github.com/pytorch/pytorch/issues/160197) on torch. 

Using .item() while returning the loss in closure resolves the warning. 
Also, since an scalar float is now being returned, calls to item() and detach() was removed as well. 