### PR TITLE
chore: correct value for linear0 layer for convnet-beyond

### DIFF
--- a/breaching/cases/models/model_preparation.py
+++ b/breaching/cases/models/model_preparation.py
@@ -352,7 +352,7 @@ def _construct_vision_model(cfg_model, cfg_data, pretrained=True, **kwargs):
                         ("conv4", torch.nn.Conv2d(128, 256, 3, stride=1, padding=1)),
                         ("relu3", torch.nn.LeakyReLU()),
                         ("flatt", torch.nn.Flatten()),
-                        ("linear0", torch.nn.Linear(12544, 12544)),
+                        ("linear0", torch.nn.Linear(16384, 12544)),
                         ("relu4", torch.nn.LeakyReLU()),
                         ("linear1", torch.nn.Linear(12544, classes)),
                         ("softmax", torch.nn.Softmax(dim=1)),


### PR DESCRIPTION
Hello. While executing the simulation with the convnet-beyond implementation, the following error will happen: 

```
    ...
    return F.linear(input, self.weight, self.bias)
RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x16384 and 12544x12544)

```

I think this is because the original paper has an different shape for the dataset. I could not find the original implementation while quick peaking at the paper. 

Im not gonna lie, I used deepseek for this one with the following prompt: 


> RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x16384 and 12544x12544)
> 
> model = torch.nn.Sequential(
>                 OrderedDict(
>                     [
>                         ("conv1", torch.nn.Conv2d(channels, 32, 3, stride=2, padding=1)),
>                         ("relu0", torch.nn.LeakyReLU()),
>                         ("conv2", torch.nn.Conv2d(32, 64, 3, stride=1, padding=1)),
>                         ("relu1", torch.nn.LeakyReLU()),
>                         ("conv3", torch.nn.Conv2d(64, 128, 3, stride=2, padding=1)),
>                         ("relu2", torch.nn.LeakyReLU()),
>                         ("conv4", torch.nn.Conv2d(128, 256, 3, stride=1, padding=1)),
>                         ("relu3", torch.nn.LeakyReLU()),
>                         ("flatt", torch.nn.Flatten()),
>                         ("linear0", torch.nn.Linear(12544, 12544)),
>                         ("relu4", torch.nn.LeakyReLU()),
>                         ("linear1", torch.nn.Linear(12544, classes)),
>                         ("softmax", torch.nn.Softmax(dim=1)),
>                     ]
>                 )
>             )
>             
>             
> this model seens to be expecting a shape of 256x256? 
> 
> I need it to expect a shape of 32x32

Which the LLMM returned: 

> The model expects input shape 256×256 (channels×7×7 after conv layers → 12544 flattened). For 32×32 input, adjust the linear layer input dimension.
> 
> Calculate new flattened size:
> - Input: 32×32
> - conv1 (stride 2): 16×16
> - conv2: 16×16
> - conv3 (stride 2): 8×8
> - conv4: 8×8
> - Flatten: 256×8×8 = 16384
> 
> Change `linear0` to:
> ```python
> ("linear0", torch.nn.Linear(16384, 12544)),

I do not know the truly reasons for that and which values must be which. But the execution works after this change: 

```
$ python simulate_breach.py attack=beyondinfering case=1_single_image_small case.user.provide_buffers=False case.user.provide_labels=True case.server.provide_public_buffers=True case.impl.enable_gpu_acc=True save_reconstruction=True dryrun=false attack.regularization.total_variation.scale=1e-4 case.model=convnet_beyond
...
[2026-02-04 16:31:04,635] Platform: linux, Python: 3.10.12, PyTorch: 2.8.0+cu128
[2026-02-04 16:31:04,645] CPUs: 10, GPUs: 1 on cisco.
[2026-02-04 16:31:04,704] GPU : NVIDIA GeForce RTX 3090
[2026-02-04 16:31:06,325] Computing user update on user 0 in model mode: eval.
[2026-02-04 16:31:08,819] | It: 1 | Rec. loss: 0.0166 |  Task loss: 2.3013 | T: 1.15s
[2026-02-04 16:31:12,157] | It: 101 | Rec. loss: 0.0001 |  Task loss: 2.3014 | T: 3.34s
[2026-02-04 16:31:13,652] | It: 201 | Rec. loss: 0.0001 |  Task loss: 2.3014 | T: 1.50s
[2026-02-04 16:31:15,147] | It: 301 | Rec. loss: 0.0001 |  Task loss: 2.3014 | T: 1.50s
[2026-02-04 16:31:16,627] | It: 400 | Rec. loss: 0.0001 |  Task loss: 2.3014 | T: 1.48s
[2026-02-04 16:31:16,637] Optimal candidate solution with rec. loss 0.0001 selected.
[2026-02-04 16:31:16,671] Starting evaluations for attack effectiveness report...
[2026-02-04 16:31:50,097] METRICS: | MSE: 0.0008 | PSNR: 30.96 | FMSE: 1.2472e-11 | LPIPS: 0.00|
 R-PSNR: 30.96 | IIP-pixel: 100.00% | SSIM: 0.9483 | max R-PSNR: 30.96 | max SSIM: 0.9483 | Label Acc: 100.00%
[2026-02-04 16:31:50,198] -------------------------------------------------------------
[2026-02-04 16:31:50,199] Finished computations default with total train time: 0:00:45.586638
[2026-02-04 16:31:50,200] -----------------Job finished.-------------------------------
```

Let me know you think another thing should change, and I'll try to make it. 